### PR TITLE
🔒 [security fix] Replace insecure HTTP links with HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ LaTeX style file and formatting instructions. The style distribution is also ava
 This repository contains
 
 * the EPTCS LaTeX style file `eptcs.cls`;
-* the default [EPTCS bibliography style](http://biblio.eptcs.org/) file `eptcs.bst` and its variants `eptcsalpha.bst`, `eptcsini.bst`, and `eptcsalphaini.bst`;
+* the default [EPTCS bibliography style](https://biblio.eptcs.org/) file `eptcs.bst` and its variants `eptcsalpha.bst`, `eptcsini.bst`, and `eptcsalphaini.bst`;
 * the file `example.tex` with instructions for both, also serving as an example template;
 * and a bibliography file `generic.bib` that is called from `example.tex`.
 
@@ -27,7 +27,7 @@ Our LaTeX style file is a small variant of the article style. The changes are:
 * A tighter bibliography (small font and less space between items)
 * A footer on the titlepage indicating the status of the paper. After processing at eptcs.org, the footer states in which volume of EPTCS the paper is published, with year, page numbers and DOI.
 * If the authors choose to invoke the option **copyright**, there will a note saying that copyright is with the authors; the authors may also dedicate the paper to the **publicdomain**.
-* By means of the style-file option **creativecommons** the authors may equip their paper with a [Creative Commons](http://creativecommons.org/) [licence](http://creativecommons.org/licenses/) that allows everyone to copy, distribute, display, and perform their copyrighted work and derivative works based upon it, but only if they give credit the way you request. By invoking the additional style-file option **noderivs** you let others copy, distribute, display, and perform only verbatim copies of your work, but not derivative works based upon it. Alternatively, the **sharealike** option allows others to distribute derivative works only under a license identical to the license that governs your work. Finally, you can invoke the option **noncommercial** that let others copy, distribute, display, and perform your work and derivative works based upon it for noncommercial purposes only. Sensible combinations of those options work as well.
+* By means of the style-file option **creativecommons** the authors may equip their paper with a [Creative Commons](https://creativecommons.org/) [licence](https://creativecommons.org/licenses/) that allows everyone to copy, distribute, display, and perform their copyrighted work and derivative works based upon it, but only if they give credit the way you request. By invoking the additional style-file option **noderivs** you let others copy, distribute, display, and perform only verbatim copies of your work, but not derivative works based upon it. Alternatively, the **sharealike** option allows others to distribute derivative works only under a license identical to the license that governs your work. Finally, you can invoke the option **noncommercial** that let others copy, distribute, display, and perform your work and derivative works based upon it for noncommercial purposes only. Sensible combinations of those options work as well.
 
 Authors may not alter the font, fontsize, textarea and margins. They may alter the other above design decisions only if this fits the paper better. Major words in the title (all but articles, prepositions, etc.) should be capitalised (unless this requirement is waived or altered by volume editors). Design decisions not governed by this style file, such as whether nontrivial words in section headers are capitalised, are left to the creativity of the authors.
 
@@ -38,6 +38,6 @@ This work is licensed under a
 
 [![CC BY 4.0][cc-by-image]][cc-by]
 
-[cc-by]: http://creativecommons.org/licenses/by/4.0/
+[cc-by]: https://creativecommons.org/licenses/by/4.0/
 [cc-by-image]: https://i.creativecommons.org/l/by/4.0/88x31.png
 [cc-by-shield]: https://img.shields.io/badge/License-CC%20BY%204.0-lightgrey.svg

--- a/example.tex
+++ b/example.tex
@@ -73,7 +73,7 @@ of your paper to be uploaded to the EPTCS website should have
 none of these style-file options.
 
 Using the style-file option
-\href{http://creativecommons.org/licenses/}{creativecommons}
+\href{https://creativecommons.org/licenses/}{creativecommons}
 authors equip their paper with a Creative Commons license that allows
 everyone to copy, distribute, display, and perform their copyrighted
 work and derivative works based upon it, but only if they give credit
@@ -234,7 +234,7 @@ submission by placing them in a directory \texttt{anc} next to the
 main latex file. See also \url{https://arxiv.org/help/ancillary_files}.
 Please add a file README in the directory \texttt{anc}, explaining the
 nature of the ancillary files, as in
-\url{http://eptcs.org/paper.cgi?226.21}.
+\url{https://eptcs.org/paper.cgi?226.21}.
 
 \section{Prefaces}
 
@@ -244,12 +244,12 @@ with {\ttfamily $\backslash$title$\{$Preface$\}$} and {\ttfamily $\backslash$aut
 \section{Bibliography}
 
 We request that you use
-\href{http://eptcs.web.cse.unsw.edu.au/eptcs.bst}
+\href{https://eptcs.web.cse.unsw.edu.au/eptcs.bst}
 {\ttfamily $\backslash$bibliographystyle$\{$eptcs$\}$}
 \cite{bibliographystylewebpage}, or one of its variants
-\href{http://eptcs.web.cse.unsw.edu.au/eptcsalpha.bst}{eptcsalpha},
-\href{http://eptcs.web.cse.unsw.edu.au/eptcsini.bst}{eptcsini} or
-\href{http://eptcs.web.cse.unsw.edu.au/eptcsalphaini.bst}{eptcsalphaini}
+\href{https://eptcs.web.cse.unsw.edu.au/eptcsalpha.bst}{eptcsalpha},
+\href{https://eptcs.web.cse.unsw.edu.au/eptcsini.bst}{eptcsini} or
+\href{https://eptcs.web.cse.unsw.edu.au/eptcsalphaini.bst}{eptcsalphaini}
 \cite{bibliographystylewebpage}. Compared to the original {\LaTeX}
 {\ttfamily $\backslash$biblio\-graphystyle$\{$plain$\}$},
 it ignores the field {\ttfamily month}, and uses the extra
@@ -281,8 +281,8 @@ publisher's response page. This is the r\^ole of the bibtex field {\ttfamily doi
 {\bfseries EPTCS requires the inclusion of a DOI in each cited paper, when available.}
 
 DOIs of papers can often be found through
-\url{http://www.crossref.org/guestquery};\footnote{For papers that will appear
-  in EPTCS and use \href{http://eptcs.web.cse.unsw.edu.au/eptcs.bst}
+\url{https://www.crossref.org/guestquery};\footnote{For papers that will appear
+  in EPTCS and use \href{https://eptcs.web.cse.unsw.edu.au/eptcs.bst}
   {\ttfamily $\backslash$bibliographystyle$\{$eptcs$\}$} there is no need to
   find DOIs on this website, as EPTCS will look them up for you
   automatically upon submission of the first version of your paper;
@@ -314,7 +314,7 @@ When using {\LaTeX} rather than {\ttfamily pdflatex} to typeset your paper, by
 default no line breaks within long URLs are allowed. This leads often
 to very ugly output, that moreover is different from the output
 generated when using {\ttfamily pdflatex}. This problem is repaired when
-invoking \href{http://eptcs.web.cse.unsw.edu.au/breakurl.sty}
+invoking \href{https://eptcs.web.cse.unsw.edu.au/breakurl.sty}
 {\ttfamily $\backslash$usepackage$\{$breakurl$\}$}: it allows line breaks
 within links and yield the same output as obtained by default with
 {\ttfamily pdflatex}.

--- a/generic.bib
+++ b/generic.bib
@@ -450,12 +450,12 @@
     ORGANIZATION = "EPTCS",
     TITLE     = "The EPTCS bibliography style",
     YEAR      = "2010",
-    EE        = "http://biblio.eptcs.org",
+    EE        = "https://biblio.eptcs.org",
     }
 
 @MISC{multipleauthors,
     TITLE     = "Centering issues with multiple authors with the same affiliation, {EPTCS} format",
-    URL       = "http://tex.stackexchange.com/q/344794/63917",
+    URL       = "https://tex.stackexchange.com/q/344794/63917",
     YEAR      = 2016,
     AUTHOR    = "Stack Exchange: gernot answering effeffe",
 }


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is the usage of insecure `http://` links for external resources in `README.md`, `example.tex`, and `generic.bib`.
⚠️ **Risk:** Using HTTP instead of HTTPS exposes users to Man-in-the-Middle (MITM) attacks where the traffic could be intercepted or modified.
🛡️ **Solution:** Updated all identified `http://` links to use `https://` to ensure secure transport.

---
*PR created automatically by Jules for task [14658425515812512637](https://jules.google.com/task/14658425515812512637) started by @k4rtik*